### PR TITLE
Update the docs and example web.yml playbook

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,12 @@ to support the `Caktus Django project template
     <http://docs.gunicorn.org/en/stable/>`_ and/or `Celery
     <http://docs.celeryproject.org/en/latest/>`_.
 
+`tequila-nodejs <https://github.com/caktus/tequila-nodejs>`_
+    A thin wrapper around `geerlingguy/nodejs
+    <https://github.com/geerlingguy/ansible-role-nodejs>`_,
+    tequila-nodejs installs nodejs and npm, installs your project
+    dependencies, and executes your front-end build script.
+
 `tequila-postgresql <https://github.com/caktus/tequila-postgresql>`_
     Install a `PostgreSQL <https://www.postgresql.org/>`_ server and
     create a project database.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,12 @@ other tooling useful for deploying `Django
     <http://docs.gunicorn.org/en/stable/>`_ and/or `Celery
     <http://docs.celeryproject.org/en/latest/>`_.
 
+`tequila-nodejs <https://github.com/caktus/tequila-nodejs>`_
+    A thin wrapper around `geerlingguy/nodejs
+    <https://github.com/geerlingguy/ansible-role-nodejs>`_,
+    tequila-nodejs installs nodejs and npm, installs your project
+    dependencies, and executes your front-end build script.
+
 `tequila-postgresql <https://github.com/caktus/tequila-postgresql>`_
     Install a `PostgreSQL <https://www.postgresql.org/>`_ server and
     create a project database.

--- a/docs/project_setup.rst
+++ b/docs/project_setup.rst
@@ -65,16 +65,20 @@ Adding Tequila to a Django Project
          version: v0.9.8
          name: tequila-django
 
+       - src: geerlingguy.nodejs
+         version: 4.1.2
+
+       - src: https://github.com/caktus/tequila-nodejs
+         version: v0.8.0
+         name: tequila-nodejs
+
        - src: https://github.com/caktus/tequila-rabbitmq
          version: v0.8.1
          name: tequila-rabbitmq
 
-       - src: geerlingguy.nodejs
-         version: 4.1.2
-
    Check to see what the most recent version is for each.
 
-   For needs that are not fulfilled by the (currently) five Tequila
+   For needs that are not fulfilled by the (currently) six Tequila
    roles, feel free to find an appropriate 3rd-party role on Ansible
    Galaxy rather than trying to roll your own.  We are currently
    making use of several roles created by `geerlingguy
@@ -96,11 +100,11 @@ Adding Tequila to a Django Project
    deal with later versions of Ubuntu and Debian lacking Python 2 by
    default), common.yml (a playbook for executing the tequila-common
    Ansible role), db.yml (tequila-postgresql), queue.yml
-   (tequila-rabbitmq), web.yml (tequila-nginx plus tequila-django),
-   worker.yml (tequila-django used for Celery), and site.yml (a
-   catch-all playbook that uses the include directive to pull in at
-   least the common, db, web, worker, and queue playbooks).  Other
-   playbooks should be created as needed to fill other
+   (tequila-rabbitmq), web.yml (tequila-nginx, tequila-django, and
+   tequila-nodejs), worker.yml (tequila-django used for Celery), and
+   site.yml (a catch-all playbook that uses the include directive to
+   pull in at least the common, db, web, worker, and queue playbooks).
+   Other playbooks should be created as needed to fill other
    project-specific needs.
 
    Make sure to sanity check the contents of each playbook for

--- a/playbooks/web.yml
+++ b/playbooks/web.yml
@@ -4,5 +4,5 @@
   roles:
     - tequila-nginx
     - { role: tequila-django, is_web: true }
-    - nodejs
+    - tequila-nodejs
 #    - awslogs


### PR DESCRIPTION
to reflect that the nodejs/npm tasks have been split out of
tequila-django into their own new role.

TEQ-63